### PR TITLE
Fixed platform-specific path creation during download.

### DIFF
--- a/Blazicons.Generating.sln
+++ b/Blazicons.Generating.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{8E7AFE26-4E33-49B5-9844-90E3D7F37A53}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{C09FD50A-DFE7-4D67-9F6F-B2CF3E607F9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C09FD50A-DFE7-4D67-9F6F-B2CF3E607F9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C09FD50A-DFE7-4D67-9F6F-B2CF3E607F9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E7AFE26-4E33-49B5-9844-90E3D7F37A53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E7AFE26-4E33-49B5-9844-90E3D7F37A53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E7AFE26-4E33-49B5-9844-90E3D7F37A53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E7AFE26-4E33-49B5-9844-90E3D7F37A53}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Blazicons.Generating/Blazicons.Generating.csproj
+++ b/Blazicons.Generating/Blazicons.Generating.csproj
@@ -31,10 +31,6 @@
   <ItemGroup>
     <PackageReference Include="CodeCasing" Version="2.0.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Blazicons.Generating/RepoDownloader.cs
+++ b/Blazicons.Generating/RepoDownloader.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Text.RegularExpressions;
 
 namespace Blazicons.Generating;

--- a/Blazicons.Generating/RepoDownloader.cs
+++ b/Blazicons.Generating/RepoDownloader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Compression;
+﻿using System.ComponentModel;
+using System.IO.Compression;
 using System.Text.RegularExpressions;
 
 namespace Blazicons.Generating;
@@ -33,7 +34,7 @@ public class RepoDownloader
 
     public string BranchName { get; }
 
-    public async Task Download(string entriesFilter = @"\.svg")
+    public async Task<IReadOnlyList<string>> Download(string entriesFilter = @"\.svg")
     {
         var fileName = Path.GetFileName(Address.AbsolutePath);
 
@@ -53,22 +54,26 @@ public class RepoDownloader
             !string.IsNullOrEmpty(x.Name)
             && Regex.IsMatch(x.FullName.Substring(RepoName.Length + 1 + BranchName.Length +1), entriesFilter));
 
+        var downloadedFiles = new List<string>();
+
         foreach (var entry in entries)
         {
-            var extractedName = Path.Combine(ExtractedFolder, entry.FullName.Replace("/", "\\"));
+            var extractedName = Path.Combine(ExtractedFolder, entry.FullName.Replace('/', Path.DirectorySeparatorChar));
             if (extractedName.Contains(".."))
             {
                 throw new InvalidOperationException($"Invalid file name '{extractedName}'");
             }
 
             var dir = Path.GetDirectoryName(extractedName);
-            if (!Directory.Exists(dir))
-            {
-                Directory.CreateDirectory(dir);
-            }
+
+            Directory.CreateDirectory(dir);
+
+            downloadedFiles.Add(extractedName);
 
             entry.ExtractToFile(extractedName);
         }
+
+        return downloadedFiles;
     }
 }
 

--- a/Tests/DownloaderTest.cs
+++ b/Tests/DownloaderTest.cs
@@ -1,4 +1,5 @@
 using Blazicons.Generating;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Tests;
 

--- a/Tests/DownloaderTest.cs
+++ b/Tests/DownloaderTest.cs
@@ -1,0 +1,21 @@
+using Blazicons.Generating;
+
+namespace Tests;
+
+[TestClass]
+public class DownloaderTest
+{
+    [TestMethod]
+    [DataRow("https://github.com/Templarian/MaterialDesign-SVG/archive/refs/heads/master.zip")]
+    public async Task TestMethod(string url)
+    {
+        var downloader = new RepoDownloader(new Uri(url));
+
+        var downloaded = await downloader!.Download();
+
+        Assert.IsTrue(downloaded.Count > 0, "There are files downloaded");
+        Assert.IsTrue(downloaded.All(x => File.Exists(x)), "All files exist");
+
+        downloader?.CleanUp();
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Blazicons.Generating\Blazicons.Generating.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Usings.cs
+++ b/Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/Tests/Usings.cs
+++ b/Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
Issue: https://github.com/kyleherzog/Blazicons.Generating/issues/2

Forcefully replacing any forward slash from the archive with hardcoded backslash results generation failure on linux machines. Replaced with platform-independent approach, 